### PR TITLE
Handle string Action,Resource as []string

### DIFF
--- a/bucketPolicyizer.go
+++ b/bucketPolicyizer.go
@@ -52,9 +52,9 @@ type Policy struct {
 // the Principal element is sometimes an
 // array and sometimes a string
 type Statement struct {
-	Sid       string
+	Sid       string `json:",omitempty"`
 	Effect    string
-	Principal interface{}
+	Principal interface{} `json:",omitempty"`
 	Action    Action
 	Resource  Resource
 }

--- a/bucketPolicyizer.go
+++ b/bucketPolicyizer.go
@@ -6,20 +6,37 @@ import (
 
 var defaultVersion = "2012-10-17"
 
-// GetObjectAction the s3 action for getting an object
-var GetObjectAction = SliceString{"s3:GetObject"}
+type Action []string
+type Resource []string
 
-type SliceString []string
-
-func (ms *SliceString) UnmarshalJSON(data []byte) error {
+// Custom json unmarshal for Resource and Action
+func _unmarshalJSON(data []byte) ([]string, error) {
 	var v []string
 	if err := json.Unmarshal(data, &v); err != nil {
 		var s string
 		if err := json.Unmarshal(data, &s); err != nil {
-			return err
+			return nil, err
 		}
-		*ms = []string{s}
-		return nil
+		return []string{s}, nil
+	}
+	return v, nil
+}
+
+// Custom json unmarshal for Action
+func (ms *Action) UnmarshalJSON(data []byte) error {
+	v, err := _unmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+	*ms = v
+	return nil
+}
+
+// Custom json unmarshal for Resource
+func (ms *Resource) UnmarshalJSON(data []byte) error {
+	v, err := _unmarshalJSON(data)
+	if err != nil {
+		return err
 	}
 	*ms = v
 	return nil
@@ -38,8 +55,8 @@ type Statement struct {
 	Sid       string
 	Effect    string
 	Principal interface{}
-	Action    SliceString
-	Resource  SliceString
+	Action    Action
+	Resource  Resource
 }
 
 // Principal is a list of ARNs

--- a/bucketPolicyizer.go
+++ b/bucketPolicyizer.go
@@ -1,11 +1,29 @@
 package bucketPolicyizer
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 var defaultVersion = "2012-10-17"
 
 // GetObjectAction the s3 action for getting an object
-var GetObjectAction = "s3:GetObject"
+var GetObjectAction = SliceString{"s3:GetObject"}
+
+type SliceString []string
+
+func (ms *SliceString) UnmarshalJSON(data []byte) error {
+	var v []string
+	if err := json.Unmarshal(data, &v); err != nil {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*ms = []string{s}
+		return nil
+	}
+	*ms = v
+	return nil
+}
 
 // Policy is the Bucket policy
 type Policy struct {
@@ -20,8 +38,8 @@ type Statement struct {
 	Sid       string
 	Effect    string
 	Principal interface{}
-	Action    []string
-	Resource  []string
+	Action    SliceString
+	Resource  SliceString
 }
 
 // Principal is a list of ARNs

--- a/bucketPolicyizer_test.go
+++ b/bucketPolicyizer_test.go
@@ -51,8 +51,8 @@ func TestActionAndResourceAsString(t *testing.T) {
 
 func TestReadOnlyFromAnonymous(t *testing.T) {
 	policy := EmptyPolicy()
-	action := GetObjectAction
-	resource := SliceString{"arn:aws:s3::exampleBucket/*"}
+	action := Action{"s3:GetObject"}
+	resource := Resource{"arn:aws:s3::exampleBucket/*"}
 	s := Statement{
 		Sid:       "AddCannedAcl",
 		Effect:    "Allow",
@@ -77,8 +77,8 @@ func TestReadOnlyFromAnonymous(t *testing.T) {
 
 func TestReadOnlyFromSpecificARN(t *testing.T) {
 	policy := EmptyPolicy()
-	action := GetObjectAction
-	resource := SliceString{"arn:aws:s3::exampleBucket/*"}
+	action := Action{"s3:GetObject"}
+	resource := Resource{"arn:aws:s3::exampleBucket/*"}
 	principal := Principal{
 		AWS: []string{"arn:aws:iam::111122223333:root", "arn:aws:iam::444455556666:root"},
 	}

--- a/bucketPolicyizer_test.go
+++ b/bucketPolicyizer_test.go
@@ -1,6 +1,7 @@
 package bucketPolicyizer
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"testing"
@@ -17,16 +18,47 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestActionAndResourceAsString(t *testing.T) {
+	policy_json := `{
+		"Version":"2012-10-17",
+		"Statement":[
+			{
+				"Sid":"AddCannedAcl",
+				"Effect":"Allow",
+				"Principal":"*",
+				"Action":"s3:GetObject",
+				"Resource":"arn:aws:s3::exampleBucket/*"
+			}
+		]
+	}`
+
+	policy := Policy{}
+	if err := json.Unmarshal([]byte(policy_json), &policy); err != nil {
+		panic(err)
+	}
+
+	p, err := CompilePolicy(policy)
+	if err != nil {
+		t.Error("couldn't compile policy", err)
+	}
+
+	sidTest := regexp.MustCompile(`AddCannedAcl`)
+	if !sidTest.MatchString(p) {
+		fmt.Println(p)
+		t.Error("couldn't match Sid")
+	}
+}
+
 func TestReadOnlyFromAnonymous(t *testing.T) {
 	policy := EmptyPolicy()
 	action := GetObjectAction
-	resource := "arn:aws:s3::exampleBucket/*"
+	resource := SliceString{"arn:aws:s3::exampleBucket/*"}
 	s := Statement{
 		Sid:       "AddCannedAcl",
 		Effect:    "Allow",
 		Principal: "*",
-		Action:    []string{action},
-		Resource:  []string{resource},
+		Action:    action,
+		Resource:  resource,
 	}
 
 	policy.Statement = []Statement{s}
@@ -46,7 +78,7 @@ func TestReadOnlyFromAnonymous(t *testing.T) {
 func TestReadOnlyFromSpecificARN(t *testing.T) {
 	policy := EmptyPolicy()
 	action := GetObjectAction
-	resource := "arn:aws:s3::exampleBucket/*"
+	resource := SliceString{"arn:aws:s3::exampleBucket/*"}
 	principal := Principal{
 		AWS: []string{"arn:aws:iam::111122223333:root", "arn:aws:iam::444455556666:root"},
 	}
@@ -55,8 +87,8 @@ func TestReadOnlyFromSpecificARN(t *testing.T) {
 		Sid:       "AddCannedAcl",
 		Effect:    "Allow",
 		Principal: principal,
-		Action:    []string{action},
-		Resource:  []string{resource},
+		Action:    action,
+		Resource:  resource,
 	}
 
 	policy.Statement = []Statement{s}


### PR DESCRIPTION
AWS converts arrays with one value to string. This patch always converts string to []string and makes unmarshalling possible!